### PR TITLE
Allow for multi-parser combat actions

### DIFF
--- a/swift/Sources/stormlight-duel/text-brain/TextBrain.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextBrain.swift
@@ -220,11 +220,22 @@ extension TextBrain {
             fatalError("Bad character ref \(characterRef)")
         }
         let parsers =
-            character.actions.compactMap {
-                $0.canReallyMaybeTakeAction(by: character.primaryKey, in: gameSnapshot)
-                    ? $0.combatChoiceParserOpt?.asAny
-                    : nil
-            } + [endTurnParser.asAny]
+            character.actions.flatMap {
+                (actionType: CombatAction.Type) -> [CliArgsParser<CombatChoice>] in
+                if !actionType.canReallyMaybeTakeAction(by: character.primaryKey, in: gameSnapshot)
+                {
+                    return []
+                }
+                if let parsers = actionType.combatChoiceParsers(
+                    context: (gameSnapshot, characterRef)
+                ) {
+                    return parsers
+                }
+                if let parser = actionType.combatChoiceParserOpt {
+                    return [parser]
+                }
+                return []
+            } + [endTurnParser]
 
         while true {
             let answer: CombatChoice = try await decideBetweenOptions(

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/CliArgsConvertibleType.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/CliArgsConvertibleType.swift
@@ -48,6 +48,12 @@ public struct CliArgsParser<T>: CliArgsParserProtocol {
         self.helpText = helpText
         self.parseFunc = parseFunc
     }
+    public func map<U>(_ mapFn: @escaping (T) -> U) -> CliArgsParser<U> {
+        CliArgsParser<U>(helpText: self.helpText) {
+            (x, y) throws(CliParseError) in
+            try self.parse(args: x, context: y).map { parsedAsT in mapFn(parsedAsT) }
+        }
+    }
 }
 extension CliArgsParser where T: CliArgsConvertibleType {
     public init(_ type: T.Type) {

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/CombatActionTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/CombatActionTextConversion.swift
@@ -20,6 +20,38 @@ extension CombatAction {
     }
 }
 
+/// Multi-parser combat actions
+
+public protocol MutliParserCombatAction: CombatAction {
+    static func combatActionParsers(context: CliArgsConversionContext) -> [CliArgsParser<Self>]
+}
+extension MutliParserCombatAction where Self: CliArgsConvertibleType {
+    public static func combatActionParsers(context: CliArgsConversionContext) -> [CliArgsParser<
+        Self
+    >] {
+        [parser]
+    }
+}
+extension MutliParserCombatAction {
+    public static func combatChoiceParsers(context: CliArgsConversionContext)
+        -> [CliArgsParser<CombatChoice>]
+    {
+        combatActionParsers(context: context).map { p in p.map { t in CombatChoice.action(t) } }
+    }
+}
+extension CombatAction {
+    public static func combatChoiceParsers(context: CliArgsConversionContext)
+        -> [CliArgsParser<CombatChoice>]?
+    {
+        if let registeredGetter = MutliParserCombatAction_registry["\(Self.self)"] {
+            return registeredGetter(context)
+        }
+        return nil
+    }
+}
+private let MutliParserCombatAction_registry:
+    [CombatActionName: @Sendable (CliArgsConversionContext) -> [CliArgsParser<CombatChoice>]] = [:]
+
 struct EndTurn {}
 @MainActor public let endTurnParser = CliArgsParser<CombatChoice>(helpText: "(e)nd") {
     args, context in


### PR DESCRIPTION
Allow for multi-parser combat actions

This should be extended to a lot more cli-parseable types, I suppose.

Make Strike into a multi-parse combat action

Calculating the available strikes maybe shouldn't go in the text conversion

Also should sort the strikes at some point