### PR TITLE
Add a big bunch of education to the text experience

### DIFF
--- a/swift/Sources/lib/KeyedSet/KeyedSet.swift
+++ b/swift/Sources/lib/KeyedSet/KeyedSet.swift
@@ -10,6 +10,10 @@ public struct KeyedSet<Element: Keyed> {
         self.core = Dictionary(uniqueKeysWithValues: core.map { ($0.primaryKey, $0) })
     }
 
+    public init<C: Collection>(removingDuplicatesFrom core: C) where C.Element == Element {
+        self.core = Dictionary(core.map { ($0.primaryKey, $0) }, uniquingKeysWith: { x, y in y })
+    }
+
     public subscript(_ key: Key) -> Element? {
         get { core[key] }
         set {

--- a/swift/Sources/stormlight-duel/game/Character/PlayerRpgCharacter/PlayerRpgCharacter.swift
+++ b/swift/Sources/stormlight-duel/game/Character/PlayerRpgCharacter/PlayerRpgCharacter.swift
@@ -27,6 +27,8 @@ extension PlayerRpgCharacterProtocol {
 }
 
 public class PlayerRpgCharacter: PlayerRpgCharacterProtocol {
+    public typealias WeaponType = any Weapon
+
     public var name: String
 
     public var size: CharacterSize { .normal }

--- a/swift/Sources/stormlight-duel/game/Character/PlayerRpgCharacter/PlayerRpgCharacter.swift
+++ b/swift/Sources/stormlight-duel/game/Character/PlayerRpgCharacter/PlayerRpgCharacter.swift
@@ -60,8 +60,11 @@ public class PlayerRpgCharacter: PlayerRpgCharacterProtocol {
     public var brain: any RpgCharacterBrain
 
     public var combatState: RpgCharacterCombatState?
-    public var actions: [any CombatAction.Type] {
-        allCombatActions + self.features.flatMap { $0.actionsProvided }
+    public var registeredActionTypes: [any CombatAction.Type] {
+        allRegisteredCombatActionTypes + self.features.flatMap { $0.actionTypesProvided }
+    }
+    public var registeredActions: [any CombatAction] {
+        allRegisteredCombatActions + self.features.flatMap { $0.actionsProvided }
     }
 
     public var isPlayer: Bool
@@ -93,7 +96,8 @@ public class PlayerRpgCharacter: PlayerRpgCharacterProtocol {
             combatState: combatState?.snapshot(),
             features: .init(
                 features.isolatedMap { AnyCharacterFeatureSnapshot($0.snapshot(in: $1)) }),
-            actions: actions,
+            registeredActionTypes: registeredActionTypes,
+            registeredActions: registeredActions,
             isPlayer: isPlayer,
         )
     }

--- a/swift/Sources/stormlight-duel/game/Character/PlayerRpgCharacter/PlayerRpgCharacterSnapshot.swift
+++ b/swift/Sources/stormlight-duel/game/Character/PlayerRpgCharacter/PlayerRpgCharacterSnapshot.swift
@@ -2,6 +2,8 @@ import CompleteDictionary
 import KeyedSet
 
 public struct PlayerRpgCharacterSnapshot: RpgCharacterSnapshot {
+    public typealias WeaponType = any WeaponSnapshot
+
     public var name: String
     public var attributes: CompleteDictionary<AttributeName, Int>
     public var ranksInCoreSkills: CompleteDictionary<CoreSkillName, Int>

--- a/swift/Sources/stormlight-duel/game/Character/PlayerRpgCharacter/PlayerRpgCharacterSnapshot.swift
+++ b/swift/Sources/stormlight-duel/game/Character/PlayerRpgCharacter/PlayerRpgCharacterSnapshot.swift
@@ -26,6 +26,7 @@ public struct PlayerRpgCharacterSnapshot: RpgCharacterSnapshot {
     public var reach: Distance
     public var combatState: RpgCharacterCombatStateSnapshot?
     public var features: KeyedSet<AnyCharacterFeatureSnapshot>
-    public var actions: [any CombatAction.Type]
+    public var registeredActionTypes: [any CombatAction.Type]
+    public var registeredActions: [any CombatAction]
     public var isPlayer: Bool
 }

--- a/swift/Sources/stormlight-duel/game/Character/PrefabCharacters/Tier1/Archer.swift
+++ b/swift/Sources/stormlight-duel/game/Character/PrefabCharacters/Tier1/Archer.swift
@@ -72,6 +72,7 @@ public struct ImmobilizingShotReactionFeature: CharacterFeature {
                 else {
                     return
                 }
+                let longbowRef = longbow.primaryKey
                 // TODO Can sense the moving subject
                 guard character.combatState!.reactionsRemaining >= 1 && character.focus.value >= 1
                 else {
@@ -120,7 +121,7 @@ public struct ImmobilizingShotReactionFeature: CharacterFeature {
                         opponent.conditions.upsert(.init(condition))
                     }
                 ]) { gameSession in
-                    try await Strike(subjectRef, with: longbow.primaryKey).action(
+                    try await Strike(subjectRef, with: longbowRef).action(
                         by: characterRef
                     )
                 }

--- a/swift/Sources/stormlight-duel/game/Character/PrefabCharacters/Tier1/Archer.swift
+++ b/swift/Sources/stormlight-duel/game/Character/PrefabCharacters/Tier1/Archer.swift
@@ -43,7 +43,9 @@ extension PrefabCharacters {
 
 public struct TakeAimActionFeature: CharacterFeature, CharacterFeatureSnapshot {
     public var name: CharacterFeatureRef { "Take Aim action" }
-    public var actionsProvided: [any CombatAction.Type] { [TakeAimAction.self] }
+    public var actionsProvided: [any CombatAction] {
+        [TakeAimAction(opponent: nil, skill: nil)]
+    }
 }
 
 public struct ImmobilizingShotReactionFeature: CharacterFeature {

--- a/swift/Sources/stormlight-duel/game/Character/RpgCharacter.swift
+++ b/swift/Sources/stormlight-duel/game/Character/RpgCharacter.swift
@@ -37,7 +37,8 @@ public protocol RpgCharacterSharedProtocol: Keyed where Key == RpgCharacterRef {
     var combatState: CombatState? { get }
     associatedtype CharacterFeatureType: CharacterFeatureSharedProtocol
     var features: KeyedSet<CharacterFeatureType> { get }
-    var actions: [CombatAction.Type] { get }
+    var registeredActionTypes: [CombatAction.Type] { get }
+    var registeredActions: [CombatAction] { get }
 
     /// Whether this character is controlled by a game player, instead of the game master.
     var isPlayer: Bool { get }
@@ -283,7 +284,8 @@ public class AnyRpgCharacter: RpgCharacter {
         set { core.combatState = newValue }
     }
     public var features: KeyedSet<AnyCharacterFeature> { core.features }
-    public var actions: [any CombatAction.Type] { core.actions }
+    public var registeredActionTypes: [any CombatAction.Type] { core.registeredActionTypes }
+    public var registeredActions: [any CombatAction] { core.registeredActions }
     public var brain: any RpgCharacterBrain { core.brain }
     public var equipment: KeyedSet<Readyable<AnyItem>> {
         get { core.equipment }

--- a/swift/Sources/stormlight-duel/game/Character/RpgCharacter.swift
+++ b/swift/Sources/stormlight-duel/game/Character/RpgCharacter.swift
@@ -49,6 +49,9 @@ public protocol RpgCharacterSharedProtocol: Keyed where Key == RpgCharacterRef {
 
     var mainHand: ItemRef? { get set }
     var offHand: ItemRef? { get set }
+
+    associatedtype WeaponType
+    var drawnWeapons: [WeaponType] { get }
 }
 extension RpgCharacterSharedProtocol {
     public var primaryKey: RpgCharacterRef {
@@ -56,10 +59,26 @@ extension RpgCharacterSharedProtocol {
     }
 }
 extension RpgCharacterSharedProtocol {
-    var modifiers: [SkillName: Int] {
+    public var modifiers: [SkillName: Int] {
         [SkillName: Int].init(
             uniqueKeysWithValues: modifiersForCoreSkills.map { (cs, v) in (SkillName.core(cs), v) }
                 + modifiersForOtherSkills.map { (os, v) in (os, v) })
+    }
+    public var drawnWeapons: [WeaponType] {
+        let main = self.mainHand.compactMap { equipment[$0]?.core.trueSelf as? WeaponType }
+        let off = self.offHand.compactMap { equipment[$0]?.core.trueSelf as? WeaponType }
+        return (main.map { [$0] } ?? []) + (off.map { [$0] } ?? [])
+    }
+}
+
+extension Optional {
+    public func compactMap<T>(_ fn: (Wrapped) -> T?) -> T? {
+        switch self {
+        case .none:
+            nil
+        case .some(let wrapped):
+            fn(wrapped)
+        }
     }
 }
 
@@ -233,6 +252,11 @@ public func doDamage(
 
 /// Cannot hold one itself recursively. `AnyRpgCharacter(AnyRpgCharacter(someChar)).core === someChar`
 public class AnyRpgCharacter: RpgCharacter {
+    public typealias CharacterFeatureType = AnyCharacterFeature
+    public typealias ConditionType = AnyCondition
+    public typealias ItemType = AnyItem
+    public typealias WeaponType = any Weapon
+
     public var name: String { core.name }
     public var attributes: CompleteDictionary<AttributeName, Int> { core.attributes }
     public var ranksInCoreSkills: CompleteDictionary<CoreSkillName, Int> { core.ranksInCoreSkills }

--- a/swift/Sources/stormlight-duel/game/Character/RpgCharacterSnapshot.swift
+++ b/swift/Sources/stormlight-duel/game/Character/RpgCharacterSnapshot.swift
@@ -12,6 +12,9 @@ where
 }
 
 public struct AnyRpgCharacterSnapshot: RpgCharacterSnapshot {
+    public typealias ItemType = AnyItemSnapshot
+    public typealias WeaponType = any WeaponSnapshot
+
     public var modifiersForCoreSkills: CompleteDictionary<CoreSkillName, Int> {
         core.modifiersForCoreSkills
     }

--- a/swift/Sources/stormlight-duel/game/Character/RpgCharacterSnapshot.swift
+++ b/swift/Sources/stormlight-duel/game/Character/RpgCharacterSnapshot.swift
@@ -38,7 +38,8 @@ public struct AnyRpgCharacterSnapshot: RpgCharacterSnapshot {
     public var size: CharacterSize { core.size }
     public var combatState: RpgCharacterCombatStateSnapshot? { core.combatState }
     public var features: KeyedSet<AnyCharacterFeatureSnapshot> { core.features }
-    public var actions: [any CombatAction.Type] { core.actions }
+    public var registeredActions: [any CombatAction] { core.registeredActions }
+    public var registeredActionTypes: [any CombatAction.Type] { core.registeredActionTypes }
     public var equipment: KeyedSet<Readyable<AnyItemSnapshot>> {
         get { core.equipment }
         set { core.equipment = newValue }

--- a/swift/Sources/stormlight-duel/game/Combat/CombatAction/CombatAction.swift
+++ b/swift/Sources/stormlight-duel/game/Combat/CombatAction/CombatAction.swift
@@ -176,11 +176,13 @@ extension CombatChoice: CustomStringConvertible {
     }
 }
 
-public let allCombatActions: [CombatAction.Type] = [
+public let allRegisteredCombatActionTypes: [CombatAction.Type] = [
     Strike.self,
-    InteractiveMove.self,
-    InteractiveGainAdvantage.self,
-    InteractiveRecover.self,
     DisengageAction.self,
-    InteractiveDrawWeapons.self,
+]
+public let allRegisteredCombatActions: [CombatAction] = [
+    InteractiveMove(),
+    InteractiveGainAdvantage(opponent: nil, chosenSkill: nil),
+    InteractiveRecover(),
+    InteractiveDrawWeapons(),
 ]

--- a/swift/Sources/stormlight-duel/game/Combat/CombatAction/Strike.swift
+++ b/swift/Sources/stormlight-duel/game/Combat/CombatAction/Strike.swift
@@ -95,7 +95,7 @@ public struct Strike: CombatAction {
         }
         guard
             let readyableItem = character.equipment[weaponToStrikeWith],
-            let weapon = readyableItem.core.core as? any WeaponSnapshot
+            let weapon = readyableItem.core.asWeapon
         else {
             return
         }

--- a/swift/Sources/stormlight-duel/game/Communication/Brain/DecisionCode.swift
+++ b/swift/Sources/stormlight-duel/game/Communication/Brain/DecisionCode.swift
@@ -1,4 +1,4 @@
-public enum DecisionCode: Sendable, Equatable {
+public enum DecisionCode: Sendable, Equatable, Hashable {
     case understanding
     case shouldGraze
     case initiative

--- a/swift/Sources/stormlight-duel/game/Features/CharacterFeature.swift
+++ b/swift/Sources/stormlight-duel/game/Features/CharacterFeature.swift
@@ -4,7 +4,8 @@ public typealias CharacterFeatureRef = String
 
 public protocol CharacterFeatureSharedProtocol: Keyed where Key == CharacterFeatureRef {
     var name: CharacterFeatureRef { get }
-    var actionsProvided: [CombatAction.Type] { get }
+    var actionTypesProvided: [CombatAction.Type] { get }
+    var actionsProvided: [CombatAction] { get }
 }
 
 public protocol CharacterFeature: Responder, CharacterFeatureSharedProtocol, Keyed
@@ -21,13 +22,15 @@ extension CharacterFeature {
 }
 extension CharacterFeatureSharedProtocol {
     public var primaryKey: Key { name }
-    public var actionsProvided: [CombatAction.Type] { [] }
+    public var actionsProvided: [CombatAction] { [] }
+    public var actionTypesProvided: [CombatAction.Type] { [] }
 }
 
 public struct AnyCharacterFeature: CharacterFeature, Keyed {
     public let core: any CharacterFeature
     public var name: CharacterFeatureRef { core.name }
-    public var actionsProvided: [any CombatAction.Type] { core.actionsProvided }
+    public var actionTypesProvided: [any CombatAction.Type] { core.actionTypesProvided }
+    public var actionsProvided: [any CombatAction] { core.actionsProvided }
     public var childResponders: [any Responder] { core.childResponders }
     public var handlers: [any EventHandlerProtocol] { core.handlers }
     public var syncHandlers: [any EventHandlerSyncProtocol] { core.syncHandlers }
@@ -56,7 +59,8 @@ extension CharacterFeature where Self: CharacterFeatureSnapshot {
 
 public struct AnyCharacterFeatureSnapshot: CharacterFeatureSnapshot {
     public var name: CharacterFeatureRef { core.name }
-    public var actionsProvided: [any CombatAction.Type] { core.actionsProvided }
+    public var actionsProvided: [any CombatAction] { core.actionsProvided }
+    public var actionTypesProvided: [any CombatAction.Type] { core.actionTypesProvided }
     public var primaryKey: String { core.primaryKey }
     public let core: any CharacterFeatureSnapshot
     public init(_ core: any CharacterFeatureSnapshot) {
@@ -70,5 +74,6 @@ public struct AnyCharacterFeatureSnapshot: CharacterFeatureSnapshot {
 
 public struct DummyCharacterFeatureSnapshot: CharacterFeatureSnapshot {
     public var name: CharacterFeatureRef
-    public var actionsProvided: [any CombatAction.Type] = []
+    public var actionTypesProvided: [any CombatAction.Type] = []
+    public var actionsProvided: [any CombatAction] = []
 }

--- a/swift/Sources/stormlight-duel/game/Item/Armor/BasicArmor.swift
+++ b/swift/Sources/stormlight-duel/game/Item/Armor/BasicArmor.swift
@@ -1,4 +1,6 @@
 public struct BasicArmor: Armor, Sendable {
+    public typealias WeaponType = any Weapon
+
     public var name: String
 
     public var price: Money?
@@ -53,6 +55,7 @@ public struct BasicArmor: Armor, Sendable {
 }
 
 public struct BasicArmorSnapshot: ArmorSnapshot {
+    public typealias WeaponType = any WeaponSnapshot
     public var name: String
     public var price: Money?
     public var weight: Weight

--- a/swift/Sources/stormlight-duel/game/Item/Item.swift
+++ b/swift/Sources/stormlight-duel/game/Item/Item.swift
@@ -1,17 +1,23 @@
 import KeyedSet
 
 public protocol ItemSharedProtocol: Keyed where Key == ItemRef {
+    associatedtype WeaponType
     var name: String { get }
     var price: Money? { get }
     var weight: Weight { get }
 
     var trueSelf: any ItemSharedProtocol { get }
+
+    var asWeapon: WeaponType? { get }
 }
 extension ItemSharedProtocol {
     public var primaryKey: ItemRef {
         ItemRef(name: self.name)
     }
     public var trueSelf: any ItemSharedProtocol { self }
+    public var asWeapon: WeaponType? {
+        trueSelf as? WeaponType
+    }
 }
 
 public struct ItemRef: Hashable, Sendable {
@@ -46,6 +52,8 @@ extension Item where Self: ItemSnapshot {
 }
 
 public struct AnyItem: Item {
+    public typealias WeaponType = any Weapon
+
     public let core: any Item
 
     public var name: String { core.name }

--- a/swift/Sources/stormlight-duel/game/Item/ItemSnapshot.swift
+++ b/swift/Sources/stormlight-duel/game/Item/ItemSnapshot.swift
@@ -1,4 +1,4 @@
-public protocol ItemSnapshot: ItemSharedProtocol, Sendable {
+public protocol ItemSnapshot: ItemSharedProtocol, Sendable where WeaponType == any WeaponSnapshot {
 }
 
 public struct AnyItemSnapshot: ItemSnapshot {

--- a/swift/Sources/stormlight-duel/game/Item/ItemSnapshot.swift
+++ b/swift/Sources/stormlight-duel/game/Item/ItemSnapshot.swift
@@ -2,6 +2,8 @@ public protocol ItemSnapshot: ItemSharedProtocol, Sendable {
 }
 
 public struct AnyItemSnapshot: ItemSnapshot {
+    public typealias WeaponType = WeaponSnapshot
+
     public let core: any ItemSnapshot
 
     public var name: String { core.name }

--- a/swift/Sources/stormlight-duel/game/Item/Weapon/BasicWeapon.swift
+++ b/swift/Sources/stormlight-duel/game/Item/Weapon/BasicWeapon.swift
@@ -1,6 +1,6 @@
 public struct BasicWeapon: Weapon, Sendable, ItemSnapshot {
     public var weaponName: WeaponName
-    public var type: WeaponType
+    public var type: WeaponSpecies
     public var weaponsSkill: WeaponsSkill
     public var range: WeaponRange
     public var damage: RandomDistribution
@@ -12,7 +12,7 @@ public struct BasicWeapon: Weapon, Sendable, ItemSnapshot {
 
     init(
         weaponName: WeaponName,
-        type: WeaponType,
+        type: WeaponSpecies,
         weaponsSkill: WeaponsSkill,
         range: WeaponRange,
         damage: RandomDistribution,

--- a/swift/Sources/stormlight-duel/game/Item/Weapon/BasicWeapon.swift
+++ b/swift/Sources/stormlight-duel/game/Item/Weapon/BasicWeapon.swift
@@ -1,4 +1,4 @@
-public struct BasicWeapon: Weapon, Sendable, ItemSnapshot {
+public struct BasicWeapon: Weapon, Sendable, WeaponSnapshot {
     public var weaponName: WeaponName
     public var type: WeaponSpecies
     public var weaponsSkill: WeaponsSkill

--- a/swift/Sources/stormlight-duel/game/Item/Weapon/BasicWeaponSnapshot.swift
+++ b/swift/Sources/stormlight-duel/game/Item/Weapon/BasicWeaponSnapshot.swift
@@ -1,30 +1,24 @@
-public struct BasicWeapon: Weapon, Sendable {
-    public typealias WeaponType = any Weapon
-    public func _snapshot(in gameSession: isolated GameSession) -> any ItemSnapshot {
-        BasicWeaponSnapshot(
-            name: name, weaponName: weaponName, type: type, weaponsSkill: weaponsSkill,
-            range: range, damage: damage, damageType: damageType, traits: traits.map { $0 },
-            price: price, weight: weight, in: gameSession)
-    }
+public struct BasicWeaponSnapshot: WeaponSnapshot, Sendable {
     public var weaponName: WeaponName
     public var type: WeaponSpecies
     public var weaponsSkill: WeaponsSkill
     public var range: WeaponRange
     public var damage: RandomDistribution
     public var damageType: DamageType
-    public var traits: [(trait: any WeaponTrait, condition: TraitCondition)]
+    public var traits: [(trait: any WeaponTraitSnapshot, condition: TraitCondition)]
     public var price: Money?
     public var weight: Weight
     public var name: String
 
     init(
+        name: String,
         weaponName: WeaponName,
         type: WeaponSpecies,
         weaponsSkill: WeaponsSkill,
         range: WeaponRange,
         damage: RandomDistribution,
         damageType: DamageType,
-        traits: [(trait: any WeaponTrait, condition: TraitCondition)],
+        traits: [(trait: any WeaponTraitSnapshot, condition: TraitCondition)],
         price: Money?,
         weight: Weight,
         in gameSession: isolated GameSession
@@ -38,7 +32,6 @@ public struct BasicWeapon: Weapon, Sendable {
         self.traits = traits
         self.price = price
         self.weight = weight
-        let id = gameSession.nextId()
-        name = "\(self.weaponName) \(id)"
+        self.name = name
     }
 }

--- a/swift/Sources/stormlight-duel/game/Item/Weapon/Weapon.swift
+++ b/swift/Sources/stormlight-duel/game/Item/Weapon/Weapon.swift
@@ -1,5 +1,5 @@
 /// An item used in combat to do the Strike action.
-public protocol WeaponSharedProtocol: Item, ItemSnapshot {
+public protocol WeaponSharedProtocol: ItemSharedProtocol {
     var type: WeaponSpecies { get }
     var weaponName: WeaponName { get }
     var weaponsSkill: WeaponsSkill { get }
@@ -8,7 +8,7 @@ public protocol WeaponSharedProtocol: Item, ItemSnapshot {
     var damageType: DamageType { get }
     var traits: [(trait: any WeaponTrait, condition: TraitCondition)] { get }
 }
-public protocol Weapon: WeaponSharedProtocol where WeaponType == any Weapon {
+public protocol Weapon: WeaponSharedProtocol, Item where WeaponType == any Weapon {
     func activeTraits(
         whenEquippedBy characterRef: RpgCharacterRef,
         in gameSnapshot: GameSnapshot,
@@ -82,7 +82,9 @@ extension Weapon {
         me.equipment[itemRef]?.isReady = true
     }
 }
-public protocol WeaponSnapshot: WeaponSharedProtocol {}
+public protocol WeaponSnapshot: WeaponSharedProtocol, ItemSnapshot
+where WeaponType == any WeaponSnapshot {
+}
 public struct AnyWeaponSnapshot: WeaponSharedProtocol {
     public init(_ core: any WeaponSnapshot) {
         self.core = core
@@ -176,10 +178,11 @@ public enum WeaponName: String, CaseIterable, Sendable, Hashable {
 }
 
 public protocol WeaponTrait: Sendable {}
+public typealias WeaponTraitSnapshot = WeaponTrait
 
 extension RpgCharacterSharedProtocol {
     func meets(_ traitCondition: TraitCondition, for weaponTrait: WeaponName) -> Bool {
-        let iAmExpert = false  // TODO Make this affected by actual expertises
+        let iAmExpert = true  // TODO Make this affected by actual expertises
         switch (traitCondition, iAmExpert) {
         case (.expert, true), (.notExpert, false), (.always, _): return true
         default: return false

--- a/swift/Sources/stormlight-duel/game/Item/Weapon/Weapon.swift
+++ b/swift/Sources/stormlight-duel/game/Item/Weapon/Weapon.swift
@@ -82,7 +82,30 @@ extension Weapon {
         me.equipment[itemRef]?.isReady = true
     }
 }
-public typealias WeaponSnapshot = WeaponSharedProtocol
+public protocol WeaponSnapshot: WeaponSharedProtocol {}
+public struct AnyWeaponSnapshot: WeaponSharedProtocol {
+    public init(_ core: any WeaponSnapshot) {
+        self.core = core
+    }
+
+    private var core: any WeaponSnapshot
+
+    public var type: WeaponSpecies { core.type }
+    public var weaponName: WeaponName { core.weaponName }
+    public var weaponsSkill: WeaponsSkill { core.weaponsSkill }
+    public var range: WeaponRange { core.range }
+    public var damage: RandomDistribution { core.damage }
+    public var damageType: DamageType { core.damageType }
+    public var traits: [(trait: any WeaponTrait, condition: TraitCondition)] { core.traits }
+    public typealias WeaponType = any WeaponSnapshot
+    public var name: String { core.name }
+    public var price: Money? { core.price }
+    public var weight: Weight { core.weight }
+    public var trueSelf: any ItemSharedProtocol { core.trueSelf }
+}
+extension AnyWeaponSnapshot: CustomStringConvertible {
+    public var description: String { "\(core)" }
+}
 
 public enum WeaponRange: Sendable, Hashable {
     case melee(extraReach: Distance? = nil)
@@ -108,6 +131,12 @@ public enum WeaponSpecies: CaseIterable, Sendable, Hashable {
 public enum WeaponsSkill: CaseIterable, Sendable, Hashable {
     case heavy
     case light
+    public var coreSkill: CoreSkillName {
+        switch self {
+        case .heavy: .heavyWeaponry
+        case .light: .lightWeaponry
+        }
+    }
 }
 
 public enum DamageType: String, CaseIterable, Sendable, Hashable {

--- a/swift/Sources/stormlight-duel/game/Item/Weapon/Weapon.swift
+++ b/swift/Sources/stormlight-duel/game/Item/Weapon/Weapon.swift
@@ -1,6 +1,6 @@
 /// An item used in combat to do the Strike action.
 public protocol WeaponSharedProtocol: Item, ItemSnapshot {
-    var type: WeaponType { get }
+    var type: WeaponSpecies { get }
     var weaponName: WeaponName { get }
     var weaponsSkill: WeaponsSkill { get }
     var range: WeaponRange { get }
@@ -8,7 +8,7 @@ public protocol WeaponSharedProtocol: Item, ItemSnapshot {
     var damageType: DamageType { get }
     var traits: [(trait: any WeaponTrait, condition: TraitCondition)] { get }
 }
-public protocol Weapon: WeaponSharedProtocol {
+public protocol Weapon: WeaponSharedProtocol where WeaponType == any Weapon {
     func activeTraits(
         whenEquippedBy characterRef: RpgCharacterRef,
         in gameSnapshot: GameSnapshot,
@@ -89,7 +89,7 @@ public enum WeaponRange: Sendable, Hashable {
     case ranged(short: Distance, long: Distance)
 }
 
-public enum WeaponType: CaseIterable, Sendable, Hashable {
+public enum WeaponSpecies: CaseIterable, Sendable, Hashable {
     case lightWeaponry
     case heavyWeaponry
     case specialWeapons

--- a/swift/Sources/stormlight-duel/game/Item/Weapon/WeaponTraits/WeaponTraitStubs.swift
+++ b/swift/Sources/stormlight-duel/game/Item/Weapon/WeaponTraits/WeaponTraitStubs.swift
@@ -1,15 +1,15 @@
 public struct Thrown: WeaponTrait {
-    var short: Distance
-    var long: Distance
+    public var short: Distance
+    public var long: Distance
 }
 public struct Offhand: WeaponTrait {}
 public struct Loaded: WeaponTrait {
-    var ammunition: Resource
+    public var ammunition: Resource
 }
 public struct TwoHanded: WeaponTrait {}
 public struct Deadly: WeaponTrait {}
 public struct CumbersomeWeapon: WeaponTrait {
-    var minStrength: Int
+    public var minStrength: Int
 }
 public struct Pierce: WeaponTrait {}
 public struct Defensive: WeaponTrait {}

--- a/swift/Sources/stormlight-duel/text-brain/OptionDescriberRegistry.swift
+++ b/swift/Sources/stormlight-duel/text-brain/OptionDescriberRegistry.swift
@@ -1,12 +1,28 @@
 import stormlight_duel
 
-public typealias OptionDescriber<T> = @Sendable (T, GameSnapshot, RpgCharacterRef) -> String
+public struct OptionDescription {
+    var name: String
+    var oneLineHelp: String? = nil
+}
+extension OptionDescription: CustomStringConvertible {
+    public var description: String {
+        name + (oneLineHelp.map { "\n  ? " + $0 } ?? "")
+    }
+}
+
+public typealias OptionDescriber<T> =
+    @Sendable (T, GameSnapshot, RpgCharacterRef) -> OptionDescription
 
 public func optionDescriber<T>(forCode code: DecisionCode, andType _: T.Type)
     -> OptionDescriber<T>
 {
     guard let untyped = describeOptionFunctionRegistry[code] else {
-        return { x, y, z in "\(x)" }
+        return { x, y, z in
+            if let describableOption = x as? DescribableOption {
+                return describableOption.optionDescription(context: (y, z))
+            }
+            return OptionDescription(name: "\(x)", oneLineHelp: nil)
+        }
     }
     return {
         x, y, z in

--- a/swift/Sources/stormlight-duel/text-brain/OptionDescriberRegistry.swift
+++ b/swift/Sources/stormlight-duel/text-brain/OptionDescriberRegistry.swift
@@ -1,0 +1,30 @@
+import stormlight_duel
+
+public typealias OptionDescriber<T> = @Sendable (T, GameSnapshot, RpgCharacterRef) -> String
+
+public func optionDescriber<T>(forCode code: DecisionCode, andType _: T.Type)
+    -> OptionDescriber<T>
+{
+    guard let untyped = describeOptionFunctionRegistry[code] else {
+        return { x, y, z in "\(x)" }
+    }
+    return {
+        x, y, z in
+        return untyped(x as T, y, z)
+    }
+}
+
+private func generalize<T>(_ fn: @escaping OptionDescriber<T>) -> OptionDescriber<Any> {
+    return {
+        x, y, z in
+        guard let x = x as? T else {
+            fatalError(
+                "TypeError: Cannot describe option of type \(type(of: x)) when it should have been a \(T.self). Value: \(x)"
+            )
+        }
+        return fn(x, y, z)
+    }
+}
+private let describeOptionFunctionRegistry: [DecisionCode: OptionDescriber<Any>] = [
+    .skillForGainAdvantage: generalize(skillForGainAdvantageOptionDescriber)
+]

--- a/swift/Sources/stormlight-duel/text-brain/OptionDescriberRegistry.swift
+++ b/swift/Sources/stormlight-duel/text-brain/OptionDescriberRegistry.swift
@@ -26,5 +26,7 @@ private func generalize<T>(_ fn: @escaping OptionDescriber<T>) -> OptionDescribe
     }
 }
 private let describeOptionFunctionRegistry: [DecisionCode: OptionDescriber<Any>] = [
-    .skillForGainAdvantage: generalize(skillForGainAdvantageOptionDescriber)
+    .skillForGainAdvantage: generalize(skillForGainAdvantageOptionDescriber),
+    .initiative: generalize(initiativeOptionDescriber),
+    .shouldGraze: generalize(grazeOptionDescriber),
 ]

--- a/swift/Sources/stormlight-duel/text-brain/ParserDescriberRegistry.swift
+++ b/swift/Sources/stormlight-duel/text-brain/ParserDescriberRegistry.swift
@@ -2,12 +2,12 @@ import stormlight_duel
 
 public typealias ParserDescriber =
     @Sendable (any CliArgsParserProtocol, GameSnapshot, RpgCharacterRef) ->
-    String
+    OptionDescription
 
 public func parserDescriber(forCode code: DecisionCode) -> ParserDescriber {
-    return parserDescriberRegistry[code] ?? { x, y, z in "\(x.helpText)" }
+    return parserDescriberRegistry[code] ?? { x, y, z in
+        OptionDescription(name: "\(x.helpText)", oneLineHelp: x.oneLineHelp)
+    }
 }
 
-private let parserDescriberRegistry: [DecisionCode: ParserDescriber] = [
-    .combatChoice: combatActionParserDescriber
-]
+private let parserDescriberRegistry: [DecisionCode: ParserDescriber] = [:]

--- a/swift/Sources/stormlight-duel/text-brain/ParserDescriberRegistry.swift
+++ b/swift/Sources/stormlight-duel/text-brain/ParserDescriberRegistry.swift
@@ -3,36 +3,11 @@ import stormlight_duel
 public typealias ParserDescriber =
     @Sendable (any CliArgsParserProtocol, GameSnapshot, RpgCharacterRef) ->
     String
-private typealias TypedParserDescriber<T> =
-    @Sendable (CliArgsParser<T>, GameSnapshot, RpgCharacterRef) ->
-    String
 
-public func parserDescriber(forCode code: DecisionCode)
-    -> ParserDescriber
-{
-    guard let untyped = parserDescriberRegistry[code] else {
-        return { x, y, z in "\(x.helpText)" }
-    }
-    return {
-        x, y, z in
-        return untyped(x, y, z)
-    }
+public func parserDescriber(forCode code: DecisionCode) -> ParserDescriber {
+    return parserDescriberRegistry[code] ?? { x, y, z in "\(x.helpText)" }
 }
 
-private func generalize<T>(as _: T.Type, _ fn: @escaping TypedParserDescriber<T>) -> ParserDescriber
-{
-    return {
-        parser, y, z in
-        return fn(
-            parser.map {
-                x in
-                guard let x = x as? T else {
-                    fatalError(
-                        "TypeError: Cannot describe parser for type \(type(of: x)) when it should have been a \(T.self). Value: \(x)"
-                    )
-                }
-                return x
-            }, y, z)
-    }
-}
-private let parserDescriberRegistry: [DecisionCode: ParserDescriber] = [:]
+private let parserDescriberRegistry: [DecisionCode: ParserDescriber] = [
+    .combatChoice: combatActionParserDescriber
+]

--- a/swift/Sources/stormlight-duel/text-brain/ParserDescriberRegistry.swift
+++ b/swift/Sources/stormlight-duel/text-brain/ParserDescriberRegistry.swift
@@ -1,0 +1,38 @@
+import stormlight_duel
+
+public typealias ParserDescriber =
+    @Sendable (any CliArgsParserProtocol, GameSnapshot, RpgCharacterRef) ->
+    String
+private typealias TypedParserDescriber<T> =
+    @Sendable (CliArgsParser<T>, GameSnapshot, RpgCharacterRef) ->
+    String
+
+public func parserDescriber(forCode code: DecisionCode)
+    -> ParserDescriber
+{
+    guard let untyped = parserDescriberRegistry[code] else {
+        return { x, y, z in "\(x.helpText)" }
+    }
+    return {
+        x, y, z in
+        return untyped(x, y, z)
+    }
+}
+
+private func generalize<T>(as _: T.Type, _ fn: @escaping TypedParserDescriber<T>) -> ParserDescriber
+{
+    return {
+        parser, y, z in
+        return fn(
+            parser.map {
+                x in
+                guard let x = x as? T else {
+                    fatalError(
+                        "TypeError: Cannot describe parser for type \(type(of: x)) when it should have been a \(T.self). Value: \(x)"
+                    )
+                }
+                return x
+            }, y, z)
+    }
+}
+private let parserDescriberRegistry: [DecisionCode: ParserDescriber] = [:]

--- a/swift/Sources/stormlight-duel/text-brain/TextBrain.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextBrain.swift
@@ -45,6 +45,7 @@ public actor TextBrain<Connection: TextInterfaceConnection>: RpgCharacterBrain {
             code, type: C.Element.self, in: gameSnapshot)
         return try await decideBetweenOptions(
             Array(options),
+            forCode: code,
             prompt: "\(code)",
             extraInterface: extraInterface,
             parsers: parsers,
@@ -59,18 +60,27 @@ public actor TextBrain<Connection: TextInterfaceConnection>: RpgCharacterBrain {
     @MainActor
     private func decideBetweenOptions<T: Sendable>(
         _ options: [T]?,
+        forCode code: DecisionCode,
         prompt: String,
         extraInterface: [String]? = nil,
         parsers: [any CliArgsParserProtocol] = [],
         displayParseableClassesInHud: Bool = false,
         in gameSnapshot: GameSnapshot,
     ) async throws -> T {
+        let describeOptionFn: OptionDescriber<T> = optionDescriber(
+            forCode: code,
+            andType: T.self
+        )
+        let describeParserFn: ParserDescriber = parserDescriber(forCode: code)
+
         var message = prompt
         message +=
-            (options?.enumerated().map { (i, x) in "\n:\(i + 1) \(x)" }.joined()
-                ?? "")
+            (options?.enumerated().map {
+                (i, x) in "\n:\(i + 1) \(describeOptionFn(x, gameSnapshot, self.characterRef))"
+            }.joined() ?? "")
         if displayParseableClassesInHud {
-            message += parsers.map { "\n:\($0.helpText)" }.joined()
+            message += parsers.map { "\n:\(describeParserFn($0, gameSnapshot, self.characterRef))" }
+                .joined()
         }
         choiceLoop: while true {
             guard
@@ -240,6 +250,7 @@ extension TextBrain {
         while true {
             let answer: CombatChoice = try await decideBetweenOptions(
                 nil,
+                forCode: .combatChoice,
                 prompt:
                     "You have \(character.combatState!.actionsRemaining) actions. What is your combat choice?",
                 parsers: parsers,
@@ -268,6 +279,7 @@ extension TextBrain {
         //await printHUD("You have \(movementRemaining) movement remaining.")
         let answer: DecideOrOther<Direction1D> = try await decideBetweenOptions(
             options,
+            forCode: .directionToMove5Ft,
             prompt: "Which direction will you step 5ft?",
             parsers: [
                 CliArgsParser<DecideOrOther<Direction1D>>(parsers: [Direction1D.parser]) {

--- a/swift/Sources/stormlight-duel/text-brain/TextBrain.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextBrain.swift
@@ -249,7 +249,9 @@ extension TextBrain {
 
         while true {
             let answer: CombatChoice = try await decideBetweenOptions(
-                nil,
+                Strike.possibleStrikes(for: self.characterRef, in: gameSnapshot).map {
+                    .action($0)
+                },
                 forCode: .combatChoice,
                 prompt:
                     "You have \(character.combatState!.actionsRemaining) actions. What is your combat choice?",

--- a/swift/Sources/stormlight-duel/text-brain/TextBrain.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextBrain.swift
@@ -230,7 +230,7 @@ extension TextBrain {
             fatalError("Bad character ref \(characterRef)")
         }
         let parsers =
-            character.actions.flatMap {
+            character.registeredActionTypes.flatMap {
                 (actionType: CombatAction.Type) -> [CliArgsParser<CombatChoice>] in
                 if !actionType.canReallyMaybeTakeAction(by: character.primaryKey, in: gameSnapshot)
                 {
@@ -241,17 +241,27 @@ extension TextBrain {
                 ) {
                     return parsers
                 }
-                if let parser = actionType.combatChoiceParserOpt {
+                if let parser = actionType.combatChoiceParserOpt(
+                    context: (gameSnapshot, characterRef))
+                {
                     return [parser]
                 }
                 return []
-            } + [endTurnParser]
+            } + [EndTurn.parser.map { _ in .endTurn }]
+        let options: [CombatChoice] =
+            Strike.possibleStrikes(
+                for: self.characterRef,
+                in: gameSnapshot
+            ).map {
+                .action($0)
+            }
+            + character.registeredActions.filter {
+                $0.canReallyTakeAction(by: characterRef, in: gameSnapshot)
+            }.map { .action($0) }
 
         while true {
             let answer: CombatChoice = try await decideBetweenOptions(
-                Strike.possibleStrikes(for: self.characterRef, in: gameSnapshot).map {
-                    .action($0)
-                },
+                options,
                 forCode: .combatChoice,
                 prompt:
                     "You have \(character.combatState!.actionsRemaining) actions. What is your combat choice?",

--- a/swift/Sources/stormlight-duel/text-brain/TextBrain.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextBrain.swift
@@ -220,11 +220,22 @@ extension TextBrain {
             fatalError("Bad character ref \(characterRef)")
         }
         let parsers =
-            character.actions.compactMap {
-                $0.canReallyMaybeTakeAction(by: character.primaryKey, in: gameSnapshot)
-                    ? $0.combatChoiceParserOpt?.asAny
-                    : nil
-            } + [endTurnParser.asAny]
+            character.actions.flatMap {
+                (actionType: CombatAction.Type) -> [CliArgsParser<CombatChoice>] in
+                if !actionType.canReallyMaybeTakeAction(by: character.primaryKey, in: gameSnapshot)
+                {
+                    return []
+                }
+                if let parsers = actionType.combatChoiceParsers(
+                    context: (gameSnapshot, characterRef)
+                ) {
+                    return parsers
+                }
+                if let parser = actionType.combatChoiceParserOpt {
+                    return [parser]
+                }
+                return []
+            } + [endTurnParser]
 
         while true {
             let answer: CombatChoice = try await decideBetweenOptions(

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Character/PrefabCharacters/ArcherTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Character/PrefabCharacters/ArcherTextConversion.swift
@@ -15,11 +15,13 @@ extension TakeAimAction: CliArgsConvertibleType {
     }
 
     public static var helpText: Substring {
-        "takeaim \(CoreSkillName.helpText) [\(RpgCharacterRef.helpText)]"
+        "takeaim [\(CoreSkillName.helpText)] [\(RpgCharacterRef.helpText)]"
     }
+    public static let oneLineHelp: String? =
+        "On your first turn, you may take Gain Advantage as a free action"
 }
 
-extension TakeAimAction: CustomStringConvertible {
+extension TakeAimAction: CustomStringConvertible, DescribableOption {
     public var description: String {
         "take aim\(self.opponent.map {" at \($0.name)"} ?? "")\(self.skill.map {" using \($0)"} ?? "")"
     }

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/CliArgsConvertibleType.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/CliArgsConvertibleType.swift
@@ -28,12 +28,14 @@ extension CliArgsConvertibleType {
 
 public protocol CliArgsParserProtocol {
     associatedtype Value
+    var valueTypeId: String { get }
     var helpText: Substring { get }
     func parse(args: [Any], context: CliArgsConversionContext) throws(CliParseError) -> Value?
     func map<U>(_ mapFn: @escaping (Value) -> U) -> CliArgsParser<U>
 }
 public struct CliArgsParser<T>: CliArgsParserProtocol {
     public let helpText: Substring
+    public var valueTypeId: String { "\(T.self)" }
     private let parseFunc:
         (_ args: [Any], _ context: CliArgsConversionContext) throws(CliParseError) -> T?
     public func parse(args: [Any], context: CliArgsConversionContext) throws(CliParseError) -> T? {

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/CliArgsConvertibleType.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/CliArgsConvertibleType.swift
@@ -30,6 +30,7 @@ public protocol CliArgsParserProtocol {
     associatedtype Value
     var helpText: Substring { get }
     func parse(args: [Any], context: CliArgsConversionContext) throws(CliParseError) -> Value?
+    func map<U>(_ mapFn: @escaping (Value) -> U) -> CliArgsParser<U>
 }
 public struct CliArgsParser<T>: CliArgsParserProtocol {
     public let helpText: Substring

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/CliArgsConvertibleType.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/CliArgsConvertibleType.swift
@@ -18,23 +18,30 @@ public protocol CliArgsConvertibleType {
     /// If it throws, it means it is trying to be this type, but it's wrong.
     init?(args: [Any], context: CliArgsConversionContext) throws(CliParseError)
     static var helpText: Substring { get }
+    static var oneLineHelp: String? { get }
 }
 extension CliArgsConvertibleType {
     public static var parser: CliArgsParser<Self> {
         CliArgsParser(Self.self)
     }
     public static var anyParser: CliArgsParser<Any> { parser.asAny }
+    public static var oneLineHelp: String? { nil }
+    public static var optionDescription: OptionDescription {
+        .init(name: "\(helpText)", oneLineHelp: oneLineHelp)
+    }
 }
 
 public protocol CliArgsParserProtocol {
     associatedtype Value
     var valueTypeId: String { get }
     var helpText: Substring { get }
+    var oneLineHelp: String? { get }
     func parse(args: [Any], context: CliArgsConversionContext) throws(CliParseError) -> Value?
     func map<U>(_ mapFn: @escaping (Value) -> U) -> CliArgsParser<U>
 }
 public struct CliArgsParser<T>: CliArgsParserProtocol {
     public let helpText: Substring
+    public let oneLineHelp: String?
     public var valueTypeId: String { "\(T.self)" }
     private let parseFunc:
         (_ args: [Any], _ context: CliArgsConversionContext) throws(CliParseError) -> T?
@@ -44,11 +51,13 @@ public struct CliArgsParser<T>: CliArgsParserProtocol {
     }
     public init(
         helpText: Substring,
+        oneLineHelp: String? = nil,
         parseFunc:
             @escaping (_ args: [Any], _ context: CliArgsConversionContext) throws(CliParseError) ->
             T?
     ) {
         self.helpText = helpText
+        self.oneLineHelp = oneLineHelp
         self.parseFunc = parseFunc
     }
     public func map<U>(_ mapFn: @escaping (T) -> U) -> CliArgsParser<U> {
@@ -62,6 +71,7 @@ extension CliArgsParser where T: CliArgsConvertibleType {
     public init(_ type: T.Type) {
         self.helpText = type.helpText
         self.parseFunc = type.init(args:context:)
+        self.oneLineHelp = type.oneLineHelp
     }
 }
 extension CliArgsParser {
@@ -77,6 +87,7 @@ extension CliArgsParser {
             return nil
         }
         self.helpText = parsers.map { $0.helpText }.joined(separator: "\n")[...]
+        self.oneLineHelp = parsers.compactMap { $0.oneLineHelp }.joined(separator: "\n")
     }
 }
 extension CliArgsParser {

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/CliArgsConvertibleType.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/CliArgsConvertibleType.swift
@@ -48,6 +48,12 @@ public struct CliArgsParser<T>: CliArgsParserProtocol {
         self.helpText = helpText
         self.parseFunc = parseFunc
     }
+    public func map<U>(_ mapFn: @escaping (T) -> U) -> CliArgsParser<U> {
+        CliArgsParser<U>(helpText: self.helpText) {
+            (x, y) throws(CliParseError) in
+            try self.parse(args: x, context: y).map { parsedAsT in mapFn(parsedAsT) }
+        }
+    }
 }
 extension CliArgsParser where T: CliArgsConvertibleType {
     public init(_ type: T.Type) {

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/CombatActionTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/CombatActionTextConversion.swift
@@ -73,3 +73,27 @@ struct EndTurn {}
     }
     return CombatChoice.endTurn
 }
+
+public func combatActionParserDescriber(
+    parser: any CliArgsParserProtocol, snapshot: GameSnapshot, characterRef: RpgCharacterRef
+) -> String {
+    guard let character = snapshot.characters[characterRef] else {
+        fatalError("Character missing")
+    }
+    return switch parser.valueTypeId {
+    case "\(Strike.self)":
+        "\(parser.helpText)\n  ? \(Strike.oneLineHelp)"
+    case "\(GainAdvantage.self)":
+        "\(parser.helpText)\n  ? \(GainAdvantage.oneLineHelp)"
+    case "\(InteractiveDrawWeapons.self)":
+        "\(parser.helpText)\n  ? \(InteractiveDrawWeapons.oneLineHelp)"
+    case "\(InteractiveRecover.self)":
+        "\(parser.helpText)\n  ? \(InteractiveRecover.oneLineHelp(character))"
+    case "\(InteractiveDrawWeapons.self)":
+        "\(parser.helpText)\n  ? \(InteractiveMove.oneLineHelp(character))"
+    default:
+        "\(parser.helpText)"
+    }
+    // TODO Actually, the parser is always returning "CombatChoice"s. Whoops.
+}
+private let d: ParserDescriber = combatActionParserDescriber

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/CombatActionTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/CombatActionTextConversion.swift
@@ -20,6 +20,38 @@ extension CombatAction {
     }
 }
 
+/// Multi-parser combat actions
+
+public protocol MutliParserCombatAction: CombatAction {
+    static func combatActionParsers(context: CliArgsConversionContext) -> [CliArgsParser<Self>]
+}
+extension MutliParserCombatAction where Self: CliArgsConvertibleType {
+    public static func combatActionParsers(context: CliArgsConversionContext) -> [CliArgsParser<
+        Self
+    >] {
+        [parser]
+    }
+}
+extension MutliParserCombatAction {
+    public static func combatChoiceParsers(context: CliArgsConversionContext)
+        -> [CliArgsParser<CombatChoice>]
+    {
+        combatActionParsers(context: context).map { p in p.map { t in CombatChoice.action(t) } }
+    }
+}
+extension CombatAction {
+    public static func combatChoiceParsers(context: CliArgsConversionContext)
+        -> [CliArgsParser<CombatChoice>]?
+    {
+        if let registeredGetter = MutliParserCombatAction_registry["\(Self.self)"] {
+            return registeredGetter(context)
+        }
+        return nil
+    }
+}
+private let MutliParserCombatAction_registry:
+    [CombatActionName: @Sendable (CliArgsConversionContext) -> [CliArgsParser<CombatChoice>]] = [:]
+
 struct EndTurn {}
 @MainActor public let endTurnParser = CliArgsParser<CombatChoice>(helpText: "(e)nd") {
     args, context in

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/CombatActionTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/CombatActionTextConversion.swift
@@ -50,7 +50,9 @@ extension CombatAction {
     }
 }
 private let MutliParserCombatAction_registry:
-    [CombatActionName: @Sendable (CliArgsConversionContext) -> [CliArgsParser<CombatChoice>]] = [:]
+    [CombatActionName: @Sendable (CliArgsConversionContext) -> [CliArgsParser<CombatChoice>]] = [
+        "\(Strike.self)": Strike.combatChoiceParsers(context:)
+    ]
 
 struct EndTurn {}
 @MainActor public let endTurnParser = CliArgsParser<CombatChoice>(helpText: "(e)nd") {

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/CombatActionTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/CombatActionTextConversion.swift
@@ -1,18 +1,23 @@
 import stormlight_duel
 
 extension CombatAction {
-    public static var parserOpt: CliArgsParser<Self>? {
+    public static func parserOpt(context: CliArgsConversionContext) -> CliArgsParser<Self>? {
         guard let parser = Self.self as? (any CliArgsConvertibleType.Type) else {
             return nil
         }
-        return CliArgsParser<Self>(helpText: parser.helpText) {
+        return CliArgsParser<Self>(
+            helpText: "[\(Self.maybeCostDescription(context: context))] \(parser.helpText)",
+            oneLineHelp: parser.oneLineHelp
+        ) {
             (args, context) throws(CliParseError) in
             let result = try parser.init(args: args, context: context)
             return result.map { $0 as! Self }
         }
     }
-    public static var combatChoiceParserOpt: CliArgsParser<CombatChoice>? {
-        Self.parserOpt.map { x in
+    public static func combatChoiceParserOpt(context: CliArgsConversionContext) -> CliArgsParser<
+        CombatChoice
+    >? {
+        Self.parserOpt(context: context).map { x in
             CliArgsParser(parsers: [x]) { action in
                 CombatChoice.action(action as! any CombatAction)
             }
@@ -54,46 +59,80 @@ private let MutliParserCombatAction_registry:
         "\(Strike.self)": Strike.combatChoiceParsers(context:)
     ]
 
-struct EndTurn {}
-@MainActor public let endTurnParser = CliArgsParser<CombatChoice>(helpText: "(e)nd") {
-    args, context in
-    if let alreadyParsedMove = args.first as? CombatChoice,
-        args.count == 1,
-        case .endTurn = alreadyParsedMove
-    {
-        return alreadyParsedMove
+// DescribableOption
+
+public protocol DescribableOption {
+    func optionDescription(context: CliArgsConversionContext) -> OptionDescription
+}
+extension DescribableOption where Self: CliArgsConvertibleType {
+    public func optionDescription(context: CliArgsConversionContext) -> OptionDescription {
+        OptionDescription(name: "\(self)", oneLineHelp: Self.oneLineHelp)
     }
-    var remaining = args[...]
-    guard
-        let firstArg = remaining.popFirst(),
-        let firstArgAsString = (firstArg as? Substring)?.lowercased(),
-        firstArgAsString == "e" || firstArgAsString == "end"
-    else {
-        return nil
-    }
-    return CombatChoice.endTurn
 }
 
-public func combatActionParserDescriber(
-    parser: any CliArgsParserProtocol, snapshot: GameSnapshot, characterRef: RpgCharacterRef
-) -> String {
-    guard let character = snapshot.characters[characterRef] else {
-        fatalError("Character missing")
+extension CombatChoice: DescribableOption {
+    public func optionDescription(context: CliArgsConversionContext) -> OptionDescription {
+        switch self {
+        case .action(let action):
+            let initialDescription: OptionDescription
+            if let describableOption = action as? DescribableOption {
+                initialDescription = describableOption.optionDescription(context: context)
+            } else {
+                initialDescription = OptionDescription(name: "\(action)")
+            }
+            return OptionDescription(
+                name: "[\(action.costDescription(context: context))] \(initialDescription.name)",
+                oneLineHelp: initialDescription.oneLineHelp)
+        case .endTurn:
+            return EndTurn.optionDescription
+        }
     }
-    return switch parser.valueTypeId {
-    case "\(Strike.self)":
-        "\(parser.helpText)\n  ? \(Strike.oneLineHelp)"
-    case "\(GainAdvantage.self)":
-        "\(parser.helpText)\n  ? \(GainAdvantage.oneLineHelp)"
-    case "\(InteractiveDrawWeapons.self)":
-        "\(parser.helpText)\n  ? \(InteractiveDrawWeapons.oneLineHelp)"
-    case "\(InteractiveRecover.self)":
-        "\(parser.helpText)\n  ? \(InteractiveRecover.oneLineHelp(character))"
-    case "\(InteractiveDrawWeapons.self)":
-        "\(parser.helpText)\n  ? \(InteractiveMove.oneLineHelp(character))"
-    default:
-        "\(parser.helpText)"
-    }
-    // TODO Actually, the parser is always returning "CombatChoice"s. Whoops.
 }
-private let d: ParserDescriber = combatActionParserDescriber
+
+// End Turn
+
+struct EndTurn: CliArgsContextFreeConvertibleType {
+    public static let helpText: Substring = "(e)nd"
+    public init() {}
+    public init?(args: [Any]) throws(CliParseError) {
+        if let alreadyParsedMove = args.first as? EndTurn,
+            args.count == 1
+        {
+            self = alreadyParsedMove
+            return
+        }
+        var remaining = args[...]
+        guard
+            let firstArg = remaining.popFirst(),
+            let firstArgAsString = (firstArg as? Substring)?.lowercased(),
+            firstArgAsString == "e" || firstArgAsString == "end"
+        else {
+            return nil
+        }
+    }
+}
+
+extension CombatAction {
+    public func costDescription(context: CliArgsConversionContext) -> String {
+        let actionCost = self.actionCost(by: context.characterRef, in: context.game)
+        let actionChunk = "\(actionCost)▶"
+        let reactionCost = self.reactionCost(by: context.characterRef, in: context.game)
+        let reactionChunk = reactionCost > 0 ? "\(reactionCost)↻" : ""
+        let focusCost = self.focusCost(by: context.characterRef, in: context.game)
+        let focusChunk = focusCost > 0 ? "\(focusCost)♦︎" : ""
+        let costChunk = [actionChunk, reactionChunk, focusChunk].filter { !$0.isEmpty }.joined(
+            separator: " ")
+        return costChunk
+    }
+    public static func maybeCostDescription(context: CliArgsConversionContext) -> String {
+        let actionCost = self.actionCost(by: context.characterRef, in: context.game)
+        let actionChunk = "\(actionCost)▶"
+        let reactionCost = self.reactionCost(by: context.characterRef, in: context.game)
+        let reactionChunk = reactionCost > 0 ? "\(reactionCost)↻" : ""
+        let focusCost = self.focusCost(by: context.characterRef, in: context.game)
+        let focusChunk = focusCost > 0 ? "\(focusCost)♦︎" : ""
+        let costChunk = [actionChunk, reactionChunk, focusChunk].filter { !$0.isEmpty }.joined(
+            separator: " ")
+        return costChunk
+    }
+}

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/DisengageTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/DisengageTextConversion.swift
@@ -31,4 +31,7 @@ extension DisengageAction: CliArgsContextFreeConvertibleType {
     public static var helpText: Substring {
         "(d)isengage \(Direction1D.helpText)"
     }
+    public static var oneLineHelp: String? {
+        "Move 5ft without triggering reactive strikes"
+    }
 }

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/InteractiveDrawWeaponsTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/InteractiveDrawWeaponsTextConversion.swift
@@ -17,14 +17,11 @@ extension InteractiveDrawWeapons: CliArgsContextFreeConvertibleType {
         self.init()
     }
 
-    public static var helpText: Substring {
-        "dra(w)"
-    }
+    public static let helpText: Substring = "dra(w)"
+    public static let oneLineHelp: String? = "Draw weapons, switch their hands, or put them away."
+
 }
 
-extension InteractiveDrawWeapons: CustomStringConvertible {
-    public var description: String { Self.actionName }
-}
-extension InteractiveDrawWeapons {
-    public static let oneLineHelp = "Draw weapons, switch their hands, or put them away."
+extension InteractiveDrawWeapons: CustomStringConvertible, DescribableOption {
+    public var description: String { "exchange weapons" }
 }

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/InteractiveDrawWeaponsTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/InteractiveDrawWeaponsTextConversion.swift
@@ -25,3 +25,6 @@ extension InteractiveDrawWeapons: CliArgsContextFreeConvertibleType {
 extension InteractiveDrawWeapons: CustomStringConvertible {
     public var description: String { Self.actionName }
 }
+extension InteractiveDrawWeapons {
+    public static let oneLineHelp = "Draw weapons, switch their hands, or put them away."
+}

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/InteractiveGainAdvantageTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/InteractiveGainAdvantageTextConversion.swift
@@ -59,3 +59,8 @@ public let skillForGainAdvantageOptionDescriber: OptionDescriber<CoreSkillName> 
         : ""
     return "\(skill) (\(bonus >= 0 ? "+" : "")\(bonus)) (\(attribute))\(warning)"
 }
+
+extension GainAdvantage {
+    static let oneLineHelp =
+        "Attempt to improve your next strike by finding a target's weakness, using one of your strengths."
+}

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/InteractiveGainAdvantageTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/InteractiveGainAdvantageTextConversion.swift
@@ -40,3 +40,13 @@ extension InteractiveGainAdvantage: CustomStringConvertible {
         "gain advantage\(self.opponent.map {" over \($0.name)"} ?? "")\(self.chosenSkill.map {" using \($0)"} ?? "")"
     }
 }
+
+public let skillForGainAdvantageOptionDescriber: OptionDescriber<CoreSkillName> = {
+    skill, snapshot, characterRef in
+    guard let character = snapshot.characters[characterRef] else {
+        fatalError("Cannot describe skill for gain advantage action")
+    }
+    let attribute = skill.attribute
+    let bonus = character.modifiersForCoreSkills[skill]
+    return "\(skill) (\(bonus >= 0 ? "+" : "")\(bonus)) (\(attribute))"
+}

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/InteractiveGainAdvantageTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/InteractiveGainAdvantageTextConversion.swift
@@ -34,9 +34,11 @@ extension InteractiveGainAdvantage: CliArgsConvertibleType {
     public static var helpText: Substring {
         "(g)ainadv \(CoreSkillName.helpText) [target]"
     }
+    public static let oneLineHelp: String? =
+        "Attempt to improve your next strike by finding a target's weakness, using one of your strengths."
 }
 
-extension InteractiveGainAdvantage: CustomStringConvertible {
+extension InteractiveGainAdvantage: CustomStringConvertible, DescribableOption {
     public var description: String {
         "gain advantage\(self.opponent.map {" over \($0.name)"} ?? "")\(self.chosenSkill.map {" using \($0)"} ?? "")"
     }
@@ -57,10 +59,6 @@ public let skillForGainAdvantageOptionDescriber: OptionDescriber<CoreSkillName> 
         weaponsYouCannotUseThisSkillFor.count > 0
         ? " [gives no advantage for \(weaponsYouCannotUseThisSkillFor.map { "\($0)" }.joined(separator: " or "))]"
         : ""
-    return "\(skill) (\(bonus >= 0 ? "+" : "")\(bonus)) (\(attribute))\(warning)"
-}
-
-extension GainAdvantage {
-    static let oneLineHelp =
-        "Attempt to improve your next strike by finding a target's weakness, using one of your strengths."
+    return OptionDescription(
+        name: "\(skill) (\(bonus >= 0 ? "+" : "")\(bonus)) (\(attribute))\(warning)")
 }

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/InteractiveGainAdvantageTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/InteractiveGainAdvantageTextConversion.swift
@@ -1,3 +1,4 @@
+import KeyedSet
 import stormlight_duel
 
 extension InteractiveGainAdvantage: CliArgsConvertibleType {
@@ -48,5 +49,13 @@ public let skillForGainAdvantageOptionDescriber: OptionDescriber<CoreSkillName> 
     }
     let attribute = skill.attribute
     let bonus = character.modifiersForCoreSkills[skill]
-    return "\(skill) (\(bonus >= 0 ? "+" : "")\(bonus)) (\(attribute))"
+    let drawnWeaponsWithDuplicates: [any WeaponSnapshot] = character.drawnWeapons
+    let drawnWeapons = KeyedSet(
+        removingDuplicatesFrom: drawnWeaponsWithDuplicates.map(AnyWeaponSnapshot.init))
+    let weaponsYouCannotUseThisSkillFor = drawnWeapons.filter { $0.weaponsSkill.coreSkill == skill }
+    let warning =
+        weaponsYouCannotUseThisSkillFor.count > 0
+        ? " [gives no advantage for \(weaponsYouCannotUseThisSkillFor.map { "\($0)" }.joined(separator: " or "))]"
+        : ""
+    return "\(skill) (\(bonus >= 0 ? "+" : "")\(bonus)) (\(attribute))\(warning)"
 }

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/InteractiveMoveTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/InteractiveMoveTextConversion.swift
@@ -45,3 +45,8 @@ extension Direction1D: CliArgsContextFreeConvertibleType {
 extension InteractiveMove: CustomStringConvertible {
     public var description: String { "move" }
 }
+extension InteractiveMove {
+    public static func oneLineHelp(_ character: any RpgCharacterSnapshot) -> String {
+        "Move up to \(character.movementRate)ft"
+    }
+}

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/InteractiveMoveTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/InteractiveMoveTextConversion.swift
@@ -1,6 +1,6 @@
 import stormlight_duel
 
-extension InteractiveMove: CliArgsContextFreeConvertibleType {
+extension InteractiveMove: CliArgsContextFreeConvertibleType, DescribableOption {
     public init?(args: [Any]) throws(CliParseError) {
         if let alreadyParsedMove = args.first as? InteractiveMove, args.count == 1 {
             self = alreadyParsedMove
@@ -18,9 +18,12 @@ extension InteractiveMove: CliArgsContextFreeConvertibleType {
     }
 
     public static var helpText: Substring { "(m)ove" }
+    public static var oneLineHelp: String? {
+        "Move up to your movement rate"
+    }
 }
 
-extension Direction1D: CliArgsContextFreeConvertibleType {
+extension Direction1D: CliArgsContextFreeConvertibleType, DescribableOption {
     public init?(args: [Any]) throws(CliParseError) {
         if let alreadyParsed = args.first as? Self, args.count == 1 {
             self = alreadyParsed
@@ -39,6 +42,24 @@ extension Direction1D: CliArgsContextFreeConvertibleType {
 
     public static var helpText: Substring {
         "R|L"
+    }
+
+    public func optionDescription(context: CliArgsConversionContext) -> OptionDescription {
+        switch self {
+        case .left: OptionDescription(name: "(l)eft")
+        case .right: OptionDescription(name: "(r)ight")
+        }
+    }
+}
+
+extension DecideOrOther: DescribableOption where T: DescribableOption {
+    public func optionDescription(context: CliArgsConversionContext) -> OptionDescription {
+        switch self {
+        case .decide(let option):
+            option.optionDescription(context: context)
+        case .other(let other):
+            OptionDescription(name: other)
+        }
     }
 }
 

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/RecoverTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/RecoverTextConversion.swift
@@ -31,3 +31,8 @@ extension HowToRecover: CustomStringConvertible {
         "restore \(amountHealth) health and \(amountFocus) focus\(amountLeftover > 0 ? ", leaving \(amountLeftover) leftover" : "")"
     }
 }
+extension InteractiveRecover {
+    public static func oneLineHelp(_ character: any RpgCharacterSnapshot) -> String {
+        "Roll your recovery die to gain \(character.recoveryDie) health or focus"
+    }
+}

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/RecoverTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/RecoverTextConversion.swift
@@ -20,10 +20,13 @@ extension InteractiveRecover: CliArgsContextFreeConvertibleType {
     public static var helpText: Substring {
         "(r)ecover"
     }
+    public static var oneLineHelp: String? {
+        "Roll your recovery die to restore health or focus"
+    }
 }
 
-extension InteractiveRecover: CustomStringConvertible {
-    public var description: String { Self.actionName }
+extension InteractiveRecover: CustomStringConvertible, DescribableOption {
+    public var description: String { "recover" }
 }
 
 extension HowToRecover: CustomStringConvertible {
@@ -33,6 +36,6 @@ extension HowToRecover: CustomStringConvertible {
 }
 extension InteractiveRecover {
     public static func oneLineHelp(_ character: any RpgCharacterSnapshot) -> String {
-        "Roll your recovery die to gain \(character.recoveryDie) health or focus"
+        "Roll your recovery die to restore \(character.recoveryDie) health or focus"
     }
 }

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/StrikeTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/StrikeTextConversion.swift
@@ -64,3 +64,26 @@ extension Strike: CliArgsConvertibleType {
 
     public static var helpText: Substring { "stri(k)e [target] [weapon]" }
 }
+
+extension Strike: MutliParserCombatAction {
+    public static func combatActionParsers(context: CliArgsConversionContext) -> [CliArgsParser<
+        Strike
+    >] {
+        let possibleStrikes = Strike.possibleStrikes(
+            for: context.characterRef,
+            in: context.game
+        )
+        // TODO sort strikes by avg damage they could do
+        return possibleStrikes.enumerated().map {
+            (i, possibleStrike) in
+            let number = "k\(i)"
+            return CliArgsParser<Strike>(helpText: "\(number) - \(possibleStrike)") {
+                args, _ in
+                guard "\(args.first, default: "")" == number else {
+                    return nil
+                }
+                return possibleStrike
+            }
+        }
+    }
+}

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/StrikeTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/StrikeTextConversion.swift
@@ -63,32 +63,42 @@ extension Strike: CliArgsConvertibleType {
     }
 
     public static var helpText: Substring { "stri(k)e [target] [weapon]" }
+    public static let oneLineHelp: String? =
+        "Deal full damage on a success, or partial damage if you choose to graze."
 }
 
 extension Strike: MutliParserCombatAction {
     public static func combatActionParsers(context: CliArgsConversionContext) -> [CliArgsParser<
         Strike
     >] {
+        []
+    }
+
+    public static func combatActionOptions(context: CliArgsConversionContext) -> [CombatAction] {
         let possibleStrikes = Strike.possibleStrikes(
             for: context.characterRef,
             in: context.game
         )
         // TODO sort strikes by avg damage they could do
-        return possibleStrikes.enumerated().map {
-            (i, possibleStrike) in
-            let number = "k\(i)"
-            return CliArgsParser<Strike>(helpText: "\(number) - \(possibleStrike)") {
-                args, _ in
-                guard "\(args.first, default: "")" == number else {
-                    return nil
-                }
-                return possibleStrike
-            }
-        }
+        return possibleStrikes
     }
 }
 
-extension Strike {
-    public static let oneLineHelp =
-        "Deal full damage on a success, or partial damage if you choose to graze."
+extension Strike: DescribableOption {
+    public func optionDescription(context: CliArgsConversionContext) -> OptionDescription {
+        let description = OptionDescription(name: "\(self)")
+        guard let character = context.game.characters[context.characterRef]?.core else {
+            return description
+        }
+        guard let weapon = character.equipment[self.weaponToStrikeWith]?.core.core.asWeapon else {
+            return description
+        }
+        let oneLineHelp =
+            "\(weapon.weaponName) (\(weapon.damage)+\(character.modifiersForCoreSkills[weapon.weaponsSkill.coreSkill]) [\(weapon.weaponsSkill.coreSkill)] \(weapon.damageType)) "
+            + "\(weapon.range) "
+            + weapon.activeTraits(whenEquippedBy: context.characterRef, in: context.game).map { t in
+                "\(t)"
+            }.joined(separator: ", ")
+        return OptionDescription(name: description.name, oneLineHelp: oneLineHelp)
+    }
 }

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/StrikeTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/CombatAction/StrikeTextConversion.swift
@@ -87,3 +87,8 @@ extension Strike: MutliParserCombatAction {
         }
     }
 }
+
+extension Strike {
+    public static let oneLineHelp =
+        "Deal full damage on a success, or partial damage if you choose to graze."
+}

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/GrazeTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/GrazeTextConversion.swift
@@ -1,0 +1,10 @@
+import stormlight_duel
+
+public let grazeOptionDescriber: OptionDescriber<GrazeChoice> = {
+    option, y, z in
+    switch option {
+    case .shouldGraze:
+        "Do damage according to your damage die, without your modifier. Costs 1 focus."
+    case .shouldNotGraze: "Miss the strike and do no damage"
+    }
+}

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/GrazeTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/GrazeTextConversion.swift
@@ -4,7 +4,11 @@ public let grazeOptionDescriber: OptionDescriber<GrazeChoice> = {
     option, y, z in
     switch option {
     case .shouldGraze:
-        "Do damage according to your damage die, without your modifier. Costs 1 focus."
-    case .shouldNotGraze: "Miss the strike and do no damage"
+        OptionDescription(
+            name: "\(option)",
+            oneLineHelp:
+                "Do damage according to your damage die, without your modifier. Costs 1 focus.")
+    case .shouldNotGraze:
+        OptionDescription(name: "\(option)", oneLineHelp: "Miss the strike and do no damage")
     }
 }

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/InitiativeTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/InitiativeTextConversion.swift
@@ -3,8 +3,13 @@ import stormlight_duel
 public let initiativeOptionDescriber: OptionDescriber<CombatTurnInitiativeChoice> = {
     option, y, z in
     switch option {
-    case .goNow: "\(option)\n  ? Get 2 actions during the fast phase, or 3 during the slow phase"
-    case .waitForSlowPhase: "\(option)\n  ? Get an extra action"
-    case .waitForOthers: "\(option)\n  ? You'll get another chance during this phase"
+    case .goNow:
+        OptionDescription(
+            name: "\(option)",
+            oneLineHelp: "Get 2 actions during the fast phase, or 3 during the slow phase")
+    case .waitForSlowPhase: OptionDescription(name: "\(option)", oneLineHelp: "Get an extra action")
+    case .waitForOthers:
+        OptionDescription(
+            name: "\(option)", oneLineHelp: "You'll get another chance during this phase")
     }
 }

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/InitiativeTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Combat/InitiativeTextConversion.swift
@@ -1,0 +1,10 @@
+import stormlight_duel
+
+public let initiativeOptionDescriber: OptionDescriber<CombatTurnInitiativeChoice> = {
+    option, y, z in
+    switch option {
+    case .goNow: "\(option)\n  ? Get 2 actions during the fast phase, or 3 during the slow phase"
+    case .waitForSlowPhase: "\(option)\n  ? Get an extra action"
+    case .waitForOthers: "\(option)\n  ? You'll get another chance during this phase"
+    }
+}

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Item/Weapon/WeaponTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Item/Weapon/WeaponTextConversion.swift
@@ -22,3 +22,20 @@ extension BasicWeapon: CustomStringConvertible {
         "\(weaponName)"
     }
 }
+
+extension BasicWeaponSnapshot: CustomStringConvertible {
+    public var description: String {
+        "\(weaponName)"
+    }
+}
+
+extension WeaponRange: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .melee(let extraReach):
+            "melee" + (extraReach.map { $0 > 0 ? " [+\($0)]" : " [\($0)]" } ?? "")
+        case .ranged(short: let shortRange, long: let longRange):
+            "ranged [\(shortRange)/\(longRange)]"
+        }
+    }
+}

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Item/Weapon/WeaponTraits/WeaponTraitTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Item/Weapon/WeaponTraits/WeaponTraitTextConversion.swift
@@ -1,0 +1,77 @@
+import stormlight_duel
+
+extension Thrown: CustomStringConvertible {
+    public var description: String {
+        "thrown (\(self.short)/\(self.long))"
+    }
+}
+extension Offhand: CustomStringConvertible {
+    public var description: String {
+        "offhand"
+    }
+}
+extension Loaded: CustomStringConvertible {
+    public var description: String {
+        "loaded (\(self.ammunition))"
+    }
+}
+extension TwoHanded: CustomStringConvertible {
+    public var description: String {
+        "two-handed"
+    }
+}
+extension Deadly: CustomStringConvertible {
+    public var description: String {
+        "deadly"
+    }
+}
+extension CumbersomeWeapon: CustomStringConvertible {
+    public var description: String {
+        "cumbersome \(self.minStrength)"
+    }
+}
+extension Pierce: CustomStringConvertible {
+    public var description: String {
+        "pierce"
+    }
+}
+extension Defensive: CustomStringConvertible {
+    public var description: String {
+        "defensive"
+    }
+}
+extension UniqueWeapon: CustomStringConvertible {
+    public var description: String {
+        "unique"
+    }
+}
+extension Momentum: CustomStringConvertible {
+    public var description: String {
+        "momentum"
+    }
+}
+extension Fragile: CustomStringConvertible {
+    public var description: String {
+        "fragile"
+    }
+}
+extension Indirect: CustomStringConvertible {
+    public var description: String {
+        "indirect"
+    }
+}
+extension Quickdraw: CustomStringConvertible {
+    public var description: String {
+        "quickdraw"
+    }
+}
+extension Dangerous: CustomStringConvertible {
+    public var description: String {
+        "dangerous"
+    }
+}
+extension Discreet: CustomStringConvertible {
+    public var description: String {
+        "discreet"
+    }
+}

--- a/swift/Sources/stormlight-duel/text-brain/TextConversion/Util/NumbersTextConversion.swift
+++ b/swift/Sources/stormlight-duel/text-brain/TextConversion/Util/NumbersTextConversion.swift
@@ -16,3 +16,9 @@ extension Int: CliArgsContextFreeConvertibleType {
 
     public static var helpText: Substring { "###" }
 }
+
+extension RandomDistribution: CustomStringConvertible {
+    public var description: String {
+        self.dice.map { (die, num) in "\(num)\(die)" }.joined(separator: "+")
+    }
+}


### PR DESCRIPTION
Allow for multi-parser combat actions

This should be extended to a lot more cli-parseable types, I suppose.

Make Strike into a multi-parse combat action

Also should sort the strikes at some point

Insert optiondescribers and parserdescribers

This will allow the same options/parsers to be presented differently to the user in different contexts

Add attribute and bonus to gain advantage

Add drawnWeapons to RpgCharacterSharedProtocol

Add WeaponSnapshot

Add weapon warning to Gain Advantage

Add helper text for several simple and less simple interactions

Separate weapons from WeaponSnapshots

Add all possible strikes as numbered options

Add OptionDescriptions for weapons and combat actions

- Move some combat actions from parseables to options
- Provide a text entry point for shield bash (even if it's not perfect)

Downside: Now you can't type "m" for move.